### PR TITLE
Scoped shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ export default Ember.View.extend(
 );
 ```
 
+## Available shortcut options
+
+* `action`: action to trigger. Can be a function or a string containing action name.
+* `global`: indicates whether events should be triggered within `input`, `textarea` and `select`. Default: `true`.
+* `scoped`: indicates that the shortcuts should only be registered for the current component/view and its children. Implies `global: true`. Default: `false`.
+* `preventDefault`: prevents the default action and stops the event from bubbling up. Applies only when the `action` is a string. Default: `false`.
+
 ## Development
 
 ### Installation

--- a/addon/create-mixin.js
+++ b/addon/create-mixin.js
@@ -39,6 +39,8 @@ export default function(bindEvent, unbindEvent) {
         if (Ember.typeOf(actionObject) === 'object') {
           if (actionObject.global === false) {
             mousetrap = new Mousetrap(document);
+          } else if (actionObject.scoped) {
+            mousetrap = new Mousetrap(self.get('element'));
           } else if (actionObject.targetElement) {
             mousetrap = new Mousetrap(actionObject.targetElement);
           }


### PR DESCRIPTION
Currently, it's impossible to have a set of shortcuts enabled only for a particular component or view. All enabled shortcuts will be applied globally to the entire application. There is an option to pass an element, but it's impossible to tell the current element while specifying shortcuts — `this` is simply not available.
This PR adds `scoped` option, which when set to true, will scope shortcuts to the element of the current component/view. I've also updated the README with a description of all available options.