### PR TITLE
Removed usage of prototype extensions

### DIFF
--- a/addon/create-mixin.js
+++ b/addon/create-mixin.js
@@ -26,7 +26,7 @@ export default function(bindEvent, unbindEvent) {
             mousetrap.bind(shortcut, function(){
               self.send(action);
               return preventDefault !== true;
-            });
+            }, eventType);
           }
           else if (type === 'function') {
             mousetrap.bind(shortcut, action.bind(self), eventType);

--- a/addon/create-mixin.js
+++ b/addon/create-mixin.js
@@ -6,7 +6,7 @@ export default function(bindEvent, unbindEvent) {
 
   return Ember.Mixin.create({
 
-    bindShortcuts: function() {
+    bindShortcuts: Ember.on(bindEvent, function() {
       var self = this;
       var shortcuts = this.get('keyboardShortcuts');
 
@@ -58,13 +58,13 @@ export default function(bindEvent, unbindEvent) {
 
       });
 
-    }.on(bindEvent),
+    }),
 
-    unbindShortcuts: function() {
+    unbindShortcuts: Ember.on(unbindEvent, function() {
       this.mousetraps.forEach(
         (mousetrap) => mousetrap.reset()
       );
-    }.on(unbindEvent)
+    })
 
   });
 

--- a/addon/create-mixin.js
+++ b/addon/create-mixin.js
@@ -19,7 +19,7 @@ export default function(bindEvent, unbindEvent) {
         var mousetrap      = new Mousetrap(document.body);
         var preventDefault = true;
 
-        function invokeAction(action) {
+        function invokeAction(action, eventType) {
           var type = Ember.typeOf(action);
 
           if (type === 'string') {
@@ -29,7 +29,7 @@ export default function(bindEvent, unbindEvent) {
             });
           }
           else if (type === 'function') {
-            mousetrap.bind(shortcut, action.bind(self));
+            mousetrap.bind(shortcut, action.bind(self), eventType);
           }
           else {
             throw new Error('Invalid value for keyboard shortcut: ' + action);
@@ -49,7 +49,7 @@ export default function(bindEvent, unbindEvent) {
             preventDefault = false;
           }
 
-          invokeAction(actionObject.action);
+          invokeAction(actionObject.action, actionObject.eventType);
         } else {
           invokeAction(actionObject);
         }

--- a/blueprints/ember-keyboard-shortcuts/index.js
+++ b/blueprints/ember-keyboard-shortcuts/index.js
@@ -4,6 +4,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('mousetrap', '~1.5.2');
+    return this.addBowerPackageToProject('mousetrap', '~1.5.3');
   }
 };


### PR DESCRIPTION
This pull request removed usage of prototype extensions since ember cli generated addons come with this https://github.com/rwjblue/ember-disable-prototype-extensions addon preinstalled. 