### PR TITLE
Allow scoped to be a selector and bind mousetrap to that selector instead of the current node.

### DIFF
--- a/addon/create-mixin.js
+++ b/addon/create-mixin.js
@@ -40,7 +40,11 @@ export default function(bindEvent, unbindEvent) {
           if (actionObject.global === false) {
             mousetrap = new Mousetrap(document);
           } else if (actionObject.scoped) {
-            mousetrap = new Mousetrap(self.get('element'));
+            if (Ember.typeOf(actionObject.scoped) === 'boolean') {
+              mousetrap = new Mousetrap(self.get('element'));
+            } else if (Ember.typeOf(actionObject.scoped) === 'string') {
+              mousetrap = new Mousetrap(document.querySelector(actionObject.scoped));
+            }
           } else if (actionObject.targetElement) {
             mousetrap = new Mousetrap(actionObject.targetElement);
           }


### PR DESCRIPTION
This change proposes allowing a shortcut to be bound to an element other than the one that defines the shortcut.

This would be useful for scenarios where you have a button component that defines shortcuts and you need to scope each instance so that you can have multiple components on the page without having their shortcuts interfere with one another.