### PR TITLE
Bind this in forEach callback

### DIFF
--- a/addon/create-mixin.js
+++ b/addon/create-mixin.js
@@ -61,7 +61,7 @@ export default function(bindEvent, unbindEvent) {
           invokeAction(actionObject);
         }
         self.mousetraps.push(mousetrap);
-      });
+      }, this);
 
     }),
 


### PR DESCRIPTION
If you hit https://github.com/Skalar/ember-keyboard-shortcuts/blob/master/addon/create-mixin.js#L44, you'll get a `Cannot read property 'get' of undefined` error in the console because `this` isn't bound in the `forEach`.

Seems we hit this line a lot in our app so it's polluting our logs!