### PR TITLE
Feature - Ensure _mousetraps is array before calling forEach

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,6 @@
 /* global Mousetrap */
 import { typeOf } from '@ember/utils';
+import { A } from '@ember/array';
 
 export function bindKeyboardShortcuts(context) {
   const shortcuts = context.get('keyboardShortcuts');
@@ -69,7 +70,7 @@ export function unbindKeyboardShortcuts(context) {
     }
     object.detachEvent('on' + type, callback);
   };
-  context._mousetraps.forEach(mousetrap => {
+  A(context._mousetraps).forEach(mousetrap => {
     // manually unbind JS event
     _removeEvent(mousetrap.target, 'keypress', mousetrap._handleKeyEvent);
     _removeEvent(mousetrap.target, 'keydown', mousetrap._handleKeyEvent);

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,5 @@
 /* global Mousetrap */
 import { typeOf } from '@ember/utils';
-import { A } from '@ember/array';
 
 export function bindKeyboardShortcuts(context) {
   const shortcuts = context.get('keyboardShortcuts');
@@ -70,7 +69,7 @@ export function unbindKeyboardShortcuts(context) {
     }
     object.detachEvent('on' + type, callback);
   };
-  A(context._mousetraps).forEach(mousetrap => {
+  Array.isArray(context._mousetraps) && context._mousetraps.forEach(mousetrap => {
     // manually unbind JS event
     _removeEvent(mousetrap.target, 'keypress', mousetrap._handleKeyEvent);
     _removeEvent(mousetrap.target, 'keydown', mousetrap._handleKeyEvent);


### PR DESCRIPTION
Coerce _mousetraps to array before calling forEach.
Ensures unregistration does not throw type error if registration has not yet first run.

This should fix #36 

My motivation is for use in a higher order component that optionally binds key handlers.  I would like to call `unbindKeyboardShortcuts` without having first called (or track that I called) `bindKeyboardShortcuts`.